### PR TITLE
Remove scalebar as useless in 3d

### DIFF
--- a/app-resources/src/main/resources/json/views/geoportal-3d.json
+++ b/app-resources/src/main/resources/json/views/geoportal-3d.json
@@ -55,7 +55,6 @@
                     {"id":"Oskari.mapframework.mapmodule.GetInfoPlugin"},
                     {"id":"Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin"},
                     {"id":"Oskari.wfsvector.WfsVectorLayerPlugin"},
-                    {"id":"Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.PanButtons"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugin"},


### PR DESCRIPTION
The scalebar isn't really designed for 3d and can give misleading results so it's better not to include it in 3D apps