### PR TITLE
Add style for 3d-tiles

### DIFF
--- a/app-resources/src/main/resources/json/layers/hki-3d-buildings.json
+++ b/app-resources/src/main/resources/json/layers/hki-3d-buildings.json
@@ -16,6 +16,15 @@
             "name": "Helsinki city 3D buildings with textures"
         }
     },
+    "options": {
+        "styles": {
+            "buildings": {
+                "fill": {
+                    "color": "#FFFFFF"
+                }
+            }
+        }
+    },
     "role_permissions": {
         "Guest" : ["VIEW_LAYER", "VIEW_PUBLISHED"],
         "User" : ["VIEW_LAYER", "VIEW_PUBLISHED", "PUBLISH"]

--- a/app-resources/src/main/resources/json/layers/hki-3d-model.json
+++ b/app-resources/src/main/resources/json/layers/hki-3d-model.json
@@ -16,6 +16,15 @@
             "name": "Helsinki city 3D"
         }
     },
+    "options": {
+        "styles": {
+            "buildings": {
+                "fill": {
+                    "color": "#FFFFFF"
+                }
+            }
+        }
+    },
     "role_permissions": {
         "Guest" : ["VIEW_LAYER", "VIEW_PUBLISHED"],
         "User" : ["VIEW_LAYER", "VIEW_PUBLISHED", "PUBLISH"]


### PR DESCRIPTION
To make demolayers for 3D-buildings look cleaner. With the default style they look a bit brown.