### PR TITLE
Add unsd plugin to dependencies (accidentally removed)

### DIFF
--- a/webapp-map/pom.xml
+++ b/webapp-map/pom.xml
@@ -62,6 +62,10 @@
             <groupId>org.oskari</groupId>
             <artifactId>service-statistics-pxweb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>service-statistics-unsd</artifactId>
+        </dependency>
         <!-- /Statistics plugins -->
 
         <dependency>


### PR DESCRIPTION
The plugin was accidentally removed in #17. Requires oskariorg/oskari-server#629