### PR TITLE
Use new shorter maven repo url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,12 @@
         <repository>
             <id>oskari_org</id>
             <name>Oskari.org release repository</name>
-            <url>https://oskari.org/nexus/content/repositories/releases/</url>
+            <url>https://oskari.org/repository/maven/releases/</url>
         </repository>
         <repository>
             <id>oskari_org_snapshot</id>
             <name>Oskari.org snapshot repository</name>
-            <url>https://oskari.org/nexus/content/repositories/snapshots/</url>
+            <url>https://oskari.org/repository/maven/snapshots/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Replace Maven repository urls `https://oskari.org/nexus/content/repositories/` with `https://oskari.org/repository/maven/`. The old one works as well but use the new ones in template.