### PR TITLE
Replace layerlist

### DIFF
--- a/app-resources/src/main/resources/json/apps/geoportal-3067.json
+++ b/app-resources/src/main/resources/json/apps/geoportal-3067.json
@@ -66,7 +66,7 @@
     { "id" : "statehandler" },
     { "id" : "search" },
     { "id" : "metadatacatalogue" },
-    { "id" : "hierarchical-layerlist" },
+    { "id" : "layerlist" },
     { "id" : "coordinatetool"},
     { "id" : "metadataflyout" },
     { "id" : "personaldata" },


### PR DESCRIPTION
This just makes a new DB use the current layerlisting bundle since hierarchical-layerlist was removed (https://github.com/oskariorg/oskari-docs/issues/245). To make an application migrate to the new list you need to switch it in an existing database with a flyway migration.