### PR TITLE
Update url and remove unnecessary opts

### DIFF
--- a/app-resources/src/main/resources/json/layers/nasa-blue-marble.json
+++ b/app-resources/src/main/resources/json/layers/nasa-blue-marble.json
@@ -1,6 +1,6 @@
 {
     "type":"wmtslayer",
-    "url":"https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/wmts.cgi",
+    "url":"https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/1.0.0/WMTSCapabilities.xml",
     "name":"BlueMarble_NextGeneration",
     "version": "1.0.0",
     "organization": "NASA EOSDIS",
@@ -11,11 +11,6 @@
         "en": {
             "name": "Blue Marble"
         }
-    },
-    "options": {
-        "requestEncoding":"REST",
-        "urlTemplate":"https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/BlueMarble_NextGeneration/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpeg",
-        "format":"image/jpeg"
     },
     "role_permissions": {
         "Guest" : ["VIEW_LAYER", "VIEW_PUBLISHED"],

--- a/app-resources/src/main/resources/json/layers/nasa-features.json
+++ b/app-resources/src/main/resources/json/layers/nasa-features.json
@@ -1,6 +1,6 @@
 {
     "type":"wmtslayer",
-    "url":"https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/wmts.cgi",
+    "url":"https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/1.0.0/WMTSCapabilities.xml",
     "name":"Reference_Features",
     "version": "1.0.0",
     "organization": "NASA EOSDIS",
@@ -11,11 +11,6 @@
         "en": {
             "name": "Features"
         }
-    },
-    "options": {
-        "requestEncoding":"REST",
-        "urlTemplate":"https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/Reference_Features/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png",
-        "format":"image/png"
     },
     "role_permissions": {
         "Guest" : ["VIEW_LAYER", "VIEW_PUBLISHED"],

--- a/app-resources/src/main/resources/json/layers/nasa-labels.json
+++ b/app-resources/src/main/resources/json/layers/nasa-labels.json
@@ -1,6 +1,6 @@
 {
     "type":"wmtslayer",
-    "url":"https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/wmts.cgi",
+    "url":"https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/1.0.0/WMTSCapabilities.xml",
     "name":"Reference_Labels",
     "version": "1.0.0",
     "organization": "NASA EOSDIS",
@@ -11,11 +11,6 @@
         "en": {
             "name": "Labels"
         }
-    },
-    "options": {
-        "requestEncoding":"REST",
-        "urlTemplate":"https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/Reference_Labels/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png",
-        "format":"image/png"
     },
     "role_permissions": {
         "Guest" : ["VIEW_LAYER", "VIEW_PUBLISHED"],

--- a/app-resources/src/main/resources/json/layers/nasa-water-mask.json
+++ b/app-resources/src/main/resources/json/layers/nasa-water-mask.json
@@ -1,6 +1,6 @@
 {
     "type":"wmtslayer",
-    "url":"https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/wmts.cgi",
+    "url":"https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/1.0.0/WMTSCapabilities.xml",
     "name":"MODIS_Water_Mask",
     "version": "1.0.0",
     "organization": "NASA EOSDIS",
@@ -11,11 +11,6 @@
         "en": {
             "name": "Water Mask"
         }
-    },
-    "options": {
-        "requestEncoding":"REST",
-        "urlTemplate":"https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Water_Mask/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png",
-        "format":"image/png"
     },
     "role_permissions": {
         "Guest" : ["VIEW_LAYER", "VIEW_PUBLISHED"],


### PR DESCRIPTION
The NASA wmts.cgi seems to give an HTML-document for "Not Found" at the end of it's GetCapabilities answer like this:
```
...
    </Contents>
    <ServiceMetadataURL xlink:href="https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/1.0.0/WMTSCapabilities.xml"/>
</Capabilities>
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL /wmts/epsg3857/best/wmts.cgi was not found on this server.</p>
</body></html>
```
Using the static file reference fixes this. Also removed the options flags as they can be deduced from capabilities.