### PR TITLE
Include JSTL dependency by default

### DIFF
--- a/webapp-map/pom.xml
+++ b/webapp-map/pom.xml
@@ -100,19 +100,12 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
+        <!-- JSTL not needed for Jetty, but required by Tomcat -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+        </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-            <id>tomcat</id>
-            <dependencies>
-                <dependency>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>jstl</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-
-    </profiles>
 
     <build>
         <finalName>${appName}</finalName>


### PR DESCRIPTION
We use it in JSP and while it's not required by Jetty it works even if we include it. This makes working with Tomcat more enjoyable.