### PR TITLE
Remove panbuttons from geoportal init scripts

### DIFF
--- a/app-resources/src/main/resources/json/apps/geoportal-3067.json
+++ b/app-resources/src/main/resources/json/apps/geoportal-3067.json
@@ -74,7 +74,6 @@
           { "id" : "Oskari.wfsvector.WfsVectorLayerPlugin" },
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin" },
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar" },
-          { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.PanButtons" },
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugin" },
           { "id":"Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin"},
           { "id" : "Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin" },

--- a/app-resources/src/main/resources/json/apps/geoportal-3067_stylized.json
+++ b/app-resources/src/main/resources/json/apps/geoportal-3067_stylized.json
@@ -74,7 +74,6 @@
           { "id" : "Oskari.wfsvector.WfsVectorLayerPlugin" },
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin" },
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar" },
-          { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.PanButtons" },
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugin" },
           { "id":"Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin"},
           { "id" : "Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin" },

--- a/app-resources/src/main/resources/json/apps/geoportal-3857.json
+++ b/app-resources/src/main/resources/json/apps/geoportal-3857.json
@@ -57,7 +57,6 @@
                     {"id":"Oskari.wfsvector.WfsVectorLayerPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar"},
-                    {"id":"Oskari.mapframework.bundle.mapmodule.plugin.PanButtons"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin"},
                     {"id":"Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin"},

--- a/app-resources/src/main/resources/json/apps/geoportal-3d.json
+++ b/app-resources/src/main/resources/json/apps/geoportal-3d.json
@@ -56,7 +56,6 @@
                     {"id":"Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin"},
                     {"id":"Oskari.wfsvector.WfsVectorLayerPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar"},
-                    {"id":"Oskari.mapframework.bundle.mapmodule.plugin.PanButtons"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin"},
                     {"id":"Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin"},


### PR DESCRIPTION
Because they provide the same reset functionality that is on the toolbar already.