### PR TITLE
Change javax servlets to jakarta servlet

### DIFF
--- a/webapp-map/pom.xml
+++ b/webapp-map/pom.xml
@@ -91,8 +91,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
@@ -106,8 +106,9 @@
         </dependency>
         <!-- JSTL not needed for Jetty, but required by Tomcat -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+            <version>2.0.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Needed to upgrade to Jakarta servlet packages because of moving to Spring 6 that uses Jakarta instead of Javax.