### PR TITLE
Switch logo and remove statsgrid from Finland views

### DIFF
--- a/app-resources/src/main/resources/json/apps/geoportal-3067.json
+++ b/app-resources/src/main/resources/json/apps/geoportal-3067.json
@@ -82,7 +82,7 @@
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin" },
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar" },
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugin" },
-          { "id":"Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin"},
+          { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin"},
           { "id" : "Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin" },
           { "id" : "Oskari.mapframework.bundle.mapmyplaces.plugin.MyPlacesLayerPlugin" },
           { "id" : "Oskari.mapframework.mapmodule.VectorLayerPlugin" },
@@ -136,7 +136,6 @@
       }
     },
     { "id" : "heatmap" },
-    { "id" : "statsgrid" },
     { "id" : "userstyle" },
     { "id" : "language-selector" }
   ]

--- a/app-resources/src/main/resources/json/apps/geoportal-3067_stylized.json
+++ b/app-resources/src/main/resources/json/apps/geoportal-3067_stylized.json
@@ -128,7 +128,6 @@
       }
     },
     { "id" : "heatmap" },
-    { "id" : "statsgrid" },
     { "id" : "language-selector" }
   ]
 }

--- a/webapp-map/src/main/webapp/WEB-INF/jsp/geoportal_stylized.jsp
+++ b/webapp-map/src/main/webapp/WEB-INF/jsp/geoportal_stylized.jsp
@@ -83,8 +83,8 @@
                 z-index: 1000;
                 position: absolute;
                 bottom: 45px;
-                left: -50px;
-                width: 146px;
+                left: -30px;
+                width: 110px;
                 transform: rotate(-90deg);
            }
             div.mappart {
@@ -210,7 +210,7 @@
 <main>
     <div class="wrapper">
         <div class="sidebar">
-            <img src="${clientDomain}/Oskari${path}/oskari_rgb_72.png" />
+            <img src="${clientDomain}/Oskari${path}/oskari_logo_white_horizontal.svg" />
         </div>
         <div class="mappart">
         <%-- Oskari uses an element with id="oskari" as it's root element by default --%>


### PR DESCRIPTION
Related to https://github.com/oskariorg/sample-application/pull/48

The data for thematic maps is world-wide and per country. It doesn't really work when we only show one country.