### PR TITLE
Remove plugins that don't use config and are automatically added

### DIFF
--- a/app-resources/src/main/resources/json/apps/embedded-3857.json
+++ b/app-resources/src/main/resources/json/apps/embedded-3857.json
@@ -48,20 +48,16 @@
                     ]
                 },
                 "plugins" : [
-                    {"id":"Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin"},
-                    {"id":"Oskari.mapframework.mapmodule.WmsLayerPlugin"},
                     {"id":"Oskari.mapframework.mapmodule.MarkersPlugin"},
                     {"id":"Oskari.mapframework.mapmodule.ControlsPlugin"},
                     {"id":"Oskari.mapframework.mapmodule.GetInfoPlugin"},
-                    {"id":"Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin"},
                     {"id":"Oskari.wfsvector.WfsVectorLayerPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.PanButtons"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin"},
                     {"id":"Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin"},
-                    {"id":"Oskari.mapframework.bundle.mapmyplaces.plugin.MyPlacesLayerPlugin"},
-                    {"id":"Oskari.mapframework.mapmodule.VectorLayerPlugin"}
+                    {"id":"Oskari.mapframework.bundle.mapmyplaces.plugin.MyPlacesLayerPlugin"}
                 ]
             },
             "state" : {

--- a/app-resources/src/main/resources/json/apps/geoportal-3067.json
+++ b/app-resources/src/main/resources/json/apps/geoportal-3067.json
@@ -72,12 +72,9 @@
           "resolutions": [2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 0.5, 0.25]
         },
         "plugins" : [
-          { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin" },
-          { "id" : "Oskari.mapframework.mapmodule.WmsLayerPlugin" },
           { "id" : "Oskari.mapframework.mapmodule.MarkersPlugin" },
           { "id" : "Oskari.mapframework.mapmodule.ControlsPlugin" },
           { "id" : "Oskari.mapframework.mapmodule.GetInfoPlugin" },
-          { "id" : "Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin" },
           { "id" : "Oskari.wfsvector.WfsVectorLayerPlugin" },
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin" },
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar" },
@@ -85,7 +82,6 @@
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin"},
           { "id" : "Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin" },
           { "id" : "Oskari.mapframework.bundle.mapmyplaces.plugin.MyPlacesLayerPlugin" },
-          { "id" : "Oskari.mapframework.mapmodule.VectorLayerPlugin" },
           { "id" : "Oskari.mapframework.mapmodule.Tiles3DLayerPlugin" }
         ],
         "layers": []

--- a/app-resources/src/main/resources/json/apps/geoportal-3067_stylized.json
+++ b/app-resources/src/main/resources/json/apps/geoportal-3067_stylized.json
@@ -65,12 +65,9 @@
           "resolutions": [2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 0.5, 0.25]
         },
         "plugins" : [
-          { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin" },
-          { "id" : "Oskari.mapframework.mapmodule.WmsLayerPlugin" },
           { "id" : "Oskari.mapframework.mapmodule.MarkersPlugin" },
           { "id" : "Oskari.mapframework.mapmodule.ControlsPlugin" },
           { "id" : "Oskari.mapframework.mapmodule.GetInfoPlugin" },
-          { "id" : "Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin" },
           { "id" : "Oskari.wfsvector.WfsVectorLayerPlugin" },
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin" },
           { "id" : "Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar" },
@@ -78,7 +75,6 @@
           { "id":"Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin"},
           { "id" : "Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin" },
           { "id" : "Oskari.mapframework.bundle.mapmyplaces.plugin.MyPlacesLayerPlugin" },
-          { "id" : "Oskari.mapframework.mapmodule.VectorLayerPlugin" },
           { "id" : "Oskari.mapframework.mapmodule.Tiles3DLayerPlugin" },
           {"id": "Oskari.mapframework.bundle.mapmodule.plugin.SearchPlugin",
             "config": {

--- a/app-resources/src/main/resources/json/apps/geoportal-3857.json
+++ b/app-resources/src/main/resources/json/apps/geoportal-3857.json
@@ -48,12 +48,9 @@
                     ]
                 },
                 "plugins" : [
-                    {"id":"Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin"},
-                    {"id":"Oskari.mapframework.mapmodule.WmsLayerPlugin"},
                     {"id":"Oskari.mapframework.mapmodule.MarkersPlugin"},
                     {"id":"Oskari.mapframework.mapmodule.ControlsPlugin"},
                     {"id":"Oskari.mapframework.mapmodule.GetInfoPlugin"},
-                    {"id":"Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin"},
                     {"id":"Oskari.wfsvector.WfsVectorLayerPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.ScaleBarPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar"},
@@ -61,7 +58,6 @@
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin"},
                     {"id":"Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmyplaces.plugin.MyPlacesLayerPlugin"},
-                    {"id":"Oskari.mapframework.mapmodule.VectorLayerPlugin"},
                     {"id": "Oskari.mapframework.mapmodule.Tiles3DLayerPlugin" },
                     {"id": "Oskari.mapframework.bundle.mapmodule.plugin.SearchPlugin" }
                 ]

--- a/app-resources/src/main/resources/json/apps/geoportal-3d.json
+++ b/app-resources/src/main/resources/json/apps/geoportal-3d.json
@@ -48,19 +48,15 @@
                     ]
                 },
                 "plugins" : [
-                    {"id":"Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin"},
-                    {"id":"Oskari.mapframework.mapmodule.WmsLayerPlugin"},
                     {"id":"Oskari.mapframework.mapmodule.MarkersPlugin"},
                     {"id":"Oskari.mapframework.mapmodule.ControlsPlugin"},
                     {"id":"Oskari.mapframework.mapmodule.GetInfoPlugin"},
-                    {"id":"Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin"},
                     {"id":"Oskari.wfsvector.WfsVectorLayerPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.Portti2Zoombar"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.FullScreenPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin"},
                     {"id":"Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin"},
                     {"id":"Oskari.mapframework.bundle.mapmyplaces.plugin.MyPlacesLayerPlugin"},
-                    {"id":"Oskari.mapframework.mapmodule.VectorLayerPlugin"},
                     {"id":"Oskari.mapframework.mapmodule.Tiles3DLayerPlugin"}
                 ]
             },

--- a/app-resources/src/main/resources/json/apps/publisher-template-3d.json
+++ b/app-resources/src/main/resources/json/apps/publisher-template-3d.json
@@ -13,10 +13,10 @@
       "id": "mapfull",
       "config": {
         "plugins": [
-          { "id" : "Oskari.wfsvector.WfsVectorLayerPlugin" },
+          { "id": "Oskari.wfsvector.WfsVectorLayerPlugin" },
           { "id": "Oskari.mapframework.bundle.mapmodule.plugin.RealtimePlugin" },
           { "id": "Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin" },
-          { "id" : "Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin"},
+          { "id": "Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin"},
           { "id": "Oskari.arcgis.bundle.maparcgis.plugin.ArcGisLayerPlugin"},
           { "id": "Oskari.mapframework.mapmodule.MarkersPlugin",
             "config" : {

--- a/app-resources/src/main/resources/json/apps/publisher-template-3d.json
+++ b/app-resources/src/main/resources/json/apps/publisher-template-3d.json
@@ -13,10 +13,7 @@
       "id": "mapfull",
       "config": {
         "plugins": [
-          { "id": "Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin" },
-          { "id": "Oskari.mapframework.mapmodule.WmsLayerPlugin" },
           { "id" : "Oskari.wfsvector.WfsVectorLayerPlugin" },
-          { "id": "Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin" },
           { "id": "Oskari.mapframework.bundle.mapmodule.plugin.RealtimePlugin" },
           { "id": "Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin" },
           { "id" : "Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin"},
@@ -26,7 +23,6 @@
               "markerButton" : false
             }
           },
-          { "id": "Oskari.mapframework.mapmodule.VectorLayerPlugin" },
           { "id": "Oskari.mapframework.mapmodule.Tiles3DLayerPlugin" }
         ],
         "layers": []

--- a/app-resources/src/main/resources/json/apps/publisher-template.json
+++ b/app-resources/src/main/resources/json/apps/publisher-template.json
@@ -13,10 +13,7 @@
       "id": "mapfull",
       "config": {
         "plugins": [
-          { "id": "Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin" },
-          { "id": "Oskari.mapframework.mapmodule.WmsLayerPlugin" },
           { "id" : "Oskari.wfsvector.WfsVectorLayerPlugin" },
-          { "id": "Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin" },
           { "id": "Oskari.mapframework.bundle.mapmodule.plugin.RealtimePlugin" },
           { "id": "Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin" },
           { "id" : "Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin"},
@@ -25,7 +22,7 @@
             "config" : {
               "markerButton" : false
             }
-          }, { "id": "Oskari.mapframework.mapmodule.VectorLayerPlugin" }
+          }
         ],
         "layers": []
       },

--- a/app-resources/src/main/resources/json/apps/publisher-template.json
+++ b/app-resources/src/main/resources/json/apps/publisher-template.json
@@ -13,10 +13,10 @@
       "id": "mapfull",
       "config": {
         "plugins": [
-          { "id" : "Oskari.wfsvector.WfsVectorLayerPlugin" },
+          { "id": "Oskari.wfsvector.WfsVectorLayerPlugin" },
           { "id": "Oskari.mapframework.bundle.mapmodule.plugin.RealtimePlugin" },
           { "id": "Oskari.mapframework.bundle.mapmodule.plugin.LogoPlugin" },
-          { "id" : "Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin"},
+          { "id": "Oskari.mapframework.bundle.myplacesimport.plugin.UserLayersLayerPlugin"},
           { "id": "Oskari.arcgis.bundle.maparcgis.plugin.ArcGisLayerPlugin"},
           { "id": "Oskari.mapframework.mapmodule.MarkersPlugin",
             "config" : {


### PR DESCRIPTION
These plugins are now automatically started even when not configured:
- `Oskari.mapframework.bundle.mapmodule.plugin.LayersPlugin`
- `Oskari.mapframework.mapmodule.VectorLayerPlugin`
- `Oskari.mapframework.mapmodule.WmsLayerPlugin`
- `Oskari.mapframework.wmts.mapmodule.plugin.WmtsLayerPlugin`

See https://github.com/oskariorg/oskari-frontend/pull/2885